### PR TITLE
Use ~/.config/aur as default folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If [cower](https://github.com/falconindy/cower) is available, it will be used to
 
 * `name` - required, name of the AUR package to install
 * `user` - required, name of the user you want to install the package as
-* `dir` - optional, name of the directory you want to download AUR packages into. If this is left blank, the module will try to use `~/aur` for the specified user.
+* `dir` - optional, name of the directory you want to download AUR packages into. If this is left blank, the module will try to use `~/.config/aur` for the specified user.
 * `skip_pgp` - optional, whether makepkg should skip verification of PGP signatures of source files. Defaults to false. This may be useful when installing packages on a target node with no keyring established.
 
 ### Examples

--- a/aur
+++ b/aur
@@ -151,9 +151,11 @@ def main():
         user = p['user']
 
     # If no directory was given, assume the packages should be downloaded to
-    # ~/aur.
+    # ~/.config/aur.
     if not p['dir']:
-        dir = '/home/%s/aur' % user
+        dir = '/home/%s/.config/aur' % user
+        if not os.path.exists(dir):
+            os.makedirs(dir)
     else:
         dir = os.path.expanduser(p['dir'])
 


### PR DESCRIPTION
In linux, `~/.config` is more a default than `~` to store app-data.

This pull request propose `~/.config/aur` as default